### PR TITLE
Migrate to lts-22.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .stack-work/
 tui.cabal
 *~
+dist-newstyle/
+stack*.yaml.lock

--- a/package.yaml
+++ b/package.yaml
@@ -8,9 +8,10 @@ library:
   dependencies:
   - base >= 4.7 && < 5
   - brick
-  - vty
-  - directory
   - cursor
+  - directory
+  - mtl
+  - vty
 
 executables:
   tui:

--- a/src/Tui.hs
+++ b/src/Tui.hs
@@ -4,11 +4,12 @@ module Tui where
 
 import System.Directory
 
-import Brick.AttrMap
-import Brick.Main
-import Brick.Types
-import Brick.Widgets.Core
-import Graphics.Vty.Input.Events
+import Brick.AttrMap             (attrMap)
+import Brick.Main                (App(..), continueWithoutRedraw, defaultMain, halt, showFirstCursor)
+import Brick.Types               (BrickEvent(VtyEvent), EventM, Widget)
+import Brick.Widgets.Core        ()
+import Graphics.Vty.Attributes   (defAttr)
+import Graphics.Vty.Input.Events (Event(EvKey), Key(KChar))
 
 tui :: IO ()
 tui = do
@@ -27,11 +28,11 @@ data ResourceName =
 tuiApp :: App TuiState e ResourceName
 tuiApp =
   App
-    { appDraw = drawTui
+    { appDraw         = drawTui
     , appChooseCursor = showFirstCursor
-    , appHandleEvent = handleTuiEvent
-    , appStartEvent = pure
-    , appAttrMap = const $ attrMap mempty []
+    , appHandleEvent  = handleTuiEvent
+    , appStartEvent   = pure ()
+    , appAttrMap      = const $ attrMap defAttr []
     }
 
 buildInitialState :: IO TuiState
@@ -40,11 +41,11 @@ buildInitialState = pure TuiState
 drawTui :: TuiState -> [Widget ResourceName]
 drawTui _ts = []
 
-handleTuiEvent :: TuiState -> BrickEvent n e -> EventM n (Next TuiState)
-handleTuiEvent s e =
+handleTuiEvent :: BrickEvent n e -> EventM n s ()
+handleTuiEvent e =
   case e of
     VtyEvent vtye ->
       case vtye of
-        EvKey (KChar 'q') [] -> halt s
-        _ -> continue s
-    _ -> continue s
+        EvKey (KChar 'q') [] -> halt
+        _ -> continueWithoutRedraw
+    _ -> continueWithoutRedraw

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,3 @@
-resolver: lts-12.18
+resolver: lts-22.0
 packages:
 - .
-extra-deps:
-- cursor-0.0.0.1
-- validity-0.8.0.0
-


### PR DESCRIPTION
`tui-base` does not build with a contemporary version of `brick`.
I updated it to the most recent lts (22) and was able to follow the tutorial, with some additional browsing of the docs about how state is now handled in `EventM`.  (So I added `mtl` to the dependencies, making `MonadState EventM` available.)